### PR TITLE
Do not pull tags when mirroring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['2.x', '3.x']
+        python-version: ['3.x']  # 2.x is supported but EOL on GitHub Actions
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019]  # TODO fails to find VC windows-2022
         log: [yes, no]
         include:

--- a/.github/workflows/copy-svn.yml
+++ b/.github/workflows/copy-svn.yml
@@ -107,7 +107,7 @@ jobs:
             flags="--force"
           fi
           remote_repo="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          git pull "$remote_repo" main --no-rebase --tags -X theirs
+          git pull "$remote_repo" main --no-rebase -X theirs
           git push "$remote_repo" --all $flags
           git push "$remote_repo" --tags $flags
 


### PR DESCRIPTION
The current automation fails with the following error

```
 ! [rejected]          v20b2      -> v20b2  (would clobber existing tag)
```

for all tags that exist in this repository. This is happening during the `git pull` stage. Since the tags in this repository should follow the repo that is being mirrored, there is no need to pull the tags.