### PR TITLE
Push only new tags

### DIFF
--- a/.github/workflows/copy-svn.yml
+++ b/.github/workflows/copy-svn.yml
@@ -30,10 +30,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: write  # for Git to git push
+
 jobs:
   copy:
-    permissions:
-      contents: write  # for Git to git push
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/copy-svn.yml
+++ b/.github/workflows/copy-svn.yml
@@ -86,6 +86,7 @@ jobs:
         working-directory: svn2git
         id: svn_tags
         run: |
+          tags=""
           git for-each-ref --format="%(refname:short) %(objectname)" refs/remotes/origin/tags \
           | while read BRANCH REF
             do
@@ -96,8 +97,10 @@ jobs:
                 echo "tag already exists"
               else
                 git tag -a -m "$BODY" $TAG_NAME $REF^
+                tags="${tags} ${TAG_NAME}"
               fi
             done
+            echo "tags=${tags}" >> ${GITHUB_OUTPUT}
 
       - name: Push to GitHub
         working-directory: svn2git
@@ -110,7 +113,11 @@ jobs:
           remote_repo="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
           git pull "$remote_repo" main --no-rebase -X theirs
           git push "$remote_repo" --all $flags
-          git push "$remote_repo" --tags $flags
+          if [[ -n "${{ steps.svn_tags.outputs.tags }}" ]]; then
+            for tag in ${{ steps.svn_tags.outputs.tags }}; do
+              git push "$remote_repo" refs/tags/${tag} $flags
+            done
+          fi
 
       - name: GC
         working-directory: svn2git


### PR DESCRIPTION
### Description

Pushing updates is still rejected for two reasons:

1. The build workflow does not have write permissions.
2. `git push --tags` errors out because it's trying to push existing tags.

To fix this:

1. Expand write permissions to the workflow scope
2. Push only existing tags